### PR TITLE
update deps, regenerate, & migrate to `tree-sitter.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "node-addon-api": "^7.1.0",
-        "node-gyp-build": "^4.8.0"
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2"
       },
       "devDependencies": {
-        "prebuildify": "^6.0.0",
+        "prebuildify": "^6.0.1",
         "tree-sitter-c": "git://github.com/tree-sitter/tree-sitter-c.git",
-        "tree-sitter-cli": "^0.22.2",
+        "tree-sitter-cli": "^0.24.3",
         "tree-sitter-cpp": "git://github.com/tree-sitter/tree-sitter-cpp.git"
       },
       "peerDependencies": {
@@ -169,10 +169,13 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.2.1.tgz",
+      "integrity": "sha512-vmEOvxwiH8tlOcv4SyE8RH34rI5/nWVaigUeAUPawC6f0+HoDthwI0vkMu4tbtsZrXq6QXFfrkhjofzKEs5tpA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
     },
     "node_modules/node-gyp-build": {
       "version": "4.8.2",
@@ -367,25 +370,18 @@
         }
       }
     },
-    "node_modules/tree-sitter-c/node_modules/node-addon-api": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.1.0.tgz",
-      "integrity": "sha512-yBY+qqWSv3dWKGODD6OGE6GnTX7Q2r+4+DfpqxHSHh8x0B4EKP9+wVGLS6U/AM1vxSNNmUEuIV5EGhYwPpfOwQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
     "node_modules/tree-sitter-cli": {
-      "version": "0.22.6",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.22.6.tgz",
-      "integrity": "sha512-s7mYOJXi8sIFkt/nLJSqlYZP96VmKTc3BAwIX0rrrlRxWjWuCwixFqwzxWZBQz4R8Hx01iP7z3cT3ih58BUmZQ==",
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.24.3.tgz",
+      "integrity": "sha512-5vS0SiJf31tMTn9CYLsu5l18qXaw5MLFka3cuGxOB5f4TtgoUSK1Sog6rKmqBc7PvFJq37YcQBjj9giNy2cJPw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
         "tree-sitter": "cli.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/tree-sitter-cpp": {
@@ -405,26 +401,6 @@
         "tree-sitter": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tree-sitter-cpp/node_modules/node-addon-api": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.1.0.tgz",
-      "integrity": "sha512-yBY+qqWSv3dWKGODD6OGE6GnTX7Q2r+4+DfpqxHSHh8x0B4EKP9+wVGLS6U/AM1vxSNNmUEuIV5EGhYwPpfOwQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
-    "node_modules/tree-sitter/node_modules/node-addon-api": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.1.0.tgz",
-      "integrity": "sha512-yBY+qqWSv3dWKGODD6OGE6GnTX7Q2r+4+DfpqxHSHh8x0B4EKP9+wVGLS6U/AM1vxSNNmUEuIV5EGhYwPpfOwQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "author": "Stephan Seitz",
   "license": "MIT",
   "dependencies": {
-    "node-addon-api": "^7.1.0",
-    "node-gyp-build": "^4.8.0"
+    "node-addon-api": "^8.2.1",
+    "node-gyp-build": "^4.8.2"
   },
   "peerDependencies": {
     "tree-sitter": "^0.21.0"
@@ -33,8 +33,8 @@
   "devDependencies": {
     "tree-sitter-c": "git://github.com/tree-sitter/tree-sitter-c.git",
     "tree-sitter-cpp": "git://github.com/tree-sitter/tree-sitter-cpp.git",
-    "tree-sitter-cli": "^0.22.2",
-    "prebuildify": "^6.0.0"
+    "tree-sitter-cli": "^0.24.3",
+    "prebuildify": "^6.0.1"
   },
   "scripts": {
     "test": "tree-sitter test",
@@ -45,13 +45,5 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/tree-sitter-grammars/tree-sitter-hlsl.git"
-  },
-  "tree-sitter": [
-    {
-      "scope": "source.cpp",
-      "file-types": [
-        "hlsl"
-      ]
-    }
-  ]
+  }
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,8 +1,7 @@
 {
-  "0": "c",
-  "1": "p",
-  "2": "p",
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
   "name": "hlsl",
+  "inherits": "cpp",
   "word": "identifier",
   "rules": {
     "translation_unit": {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4522,19 +4522,11 @@
       "required": false,
       "types": [
         {
-          "type": "identifier",
-          "named": true
-        },
-        {
           "type": "optional_parameter_declaration",
           "named": true
         },
         {
           "type": "parameter_declaration",
-          "named": true
-        },
-        {
-          "type": "variadic_parameter",
           "named": true
         },
         {
@@ -6615,6 +6607,7 @@
   {
     "type": "translation_unit",
     "named": true,
+    "root": true,
     "fields": {},
     "children": {
       "multiple": true,
@@ -7146,11 +7139,6 @@
         }
       ]
     }
-  },
-  {
-    "type": "variadic_parameter",
-    "named": true,
-    "fields": {}
   },
   {
     "type": "variadic_parameter_declaration",

--- a/src/tree_sitter/alloc.h
+++ b/src/tree_sitter/alloc.h
@@ -12,10 +12,10 @@ extern "C" {
 // Allow clients to override allocation functions
 #ifdef TREE_SITTER_REUSE_ALLOCATOR
 
-extern void *(*ts_current_malloc)(size_t);
-extern void *(*ts_current_calloc)(size_t, size_t);
-extern void *(*ts_current_realloc)(void *, size_t);
-extern void (*ts_current_free)(void *);
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
 
 #ifndef ts_malloc
 #define ts_malloc  ts_current_malloc

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -47,6 +47,7 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,34 @@
+{
+  "grammars": [
+    {
+      "name": "hlsl",
+      "camelcase": "Hlsl",
+      "scope": "source.cpp",
+      "path": ".",
+      "file-types": [
+        "hlsl"
+      ]
+    }
+  ],
+  "metadata": {
+    "version": "0.1.5",
+    "license": "MIT",
+    "description": "HLSL grammar for tree-sitter (based on tree-sitter-c",
+    "authors": [
+      {
+        "name": "Stephan Seitz"
+      }
+    ],
+    "links": {
+      "repository": "git://github.com/tree-sitter-grammars/tree-sitter-hlsl.git"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
This fixes the panic with the CLI on the latest commit on tree-sitter master because the `grammar.json` is malformed