### PR TITLE
bindings!: require Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Topic :: Text Processing :: Linguistic",
   "Typing :: Typed"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license.text = "MIT"
 readme = "README.md"
 
@@ -25,5 +25,5 @@ Homepage = "https://github.com/tree-sitter-grammars/tree-sitter-hlsl"
 core = ["tree-sitter~=0.22"]
 
 [tool.cibuildwheel]
-build = "cp38-*"
+build = "cp39-*"
 build-frontend = "build"


### PR DESCRIPTION
Python 3.8 is EOL and requiring Python 3.9 fixes our release workflow for Python