### PR TITLE
fix grammer for work graph spec, fixes for flow control multi-decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 node_modules
 build
 test/kajiya
+*.exp
+*.lib
+*.dll
+*.pdb
+*.obj
+*.o
+*.so

--- a/grammar.js
+++ b/grammar.js
@@ -5,16 +5,15 @@ module.exports = grammar(CPP, {
 
     conflicts: ($, original) => original.concat([
         [$.function_declarator],
+        [$.hlsl_attribute, $.subscript_designator],
     ]),
 
     rules: {
         _top_level_item: (_, original) => original,
 
         function_definition: ($, original) => seq(
-            optional(
-                $.hlsl_attribute,
-            )
-            , original
+            repeat($.hlsl_attribute),
+            original
         ),
         function_declarator: ($, original) => seq(
             original,
@@ -40,6 +39,7 @@ module.exports = grammar(CPP, {
 
         parameter_declaration: ($, original) =>
             seq(
+                repeat($.hlsl_attribute),
                 original,
                 optional($.semantics),
             ),
@@ -48,7 +48,7 @@ module.exports = grammar(CPP, {
 
         _non_case_statement: ($, original) => choice($.discard_statement, $.cbuffer_specifier, original),
 
-        if_statement: ($, original) => seq(optional($.hlsl_attribute), original),
+        if_statement: ($, original) => seq(repeat($.hlsl_attribute), original),
 
         discard_statement: _ => seq('discard', ';'),
         qualifiers: _ => choice(
@@ -91,7 +91,7 @@ module.exports = grammar(CPP, {
             $.expression,
             ']'),
 
-        for_statement: ($, original) => seq(optional($.hlsl_attribute), original),
+        for_statement: ($, original) => seq(repeat($.hlsl_attribute), original),
 
     }
 });

--- a/grammar.js
+++ b/grammar.js
@@ -1,101 +1,112 @@
 const CPP = require("tree-sitter-cpp/grammar")
 
 module.exports = grammar(CPP, {
-    name: 'hlsl',
+  name: 'hlsl',
 
-    conflicts: ($, original) => original.concat([
-        [$.function_declarator],
-        [$.hlsl_attribute, $.subscript_designator],
-    ]),
-
-    rules: {
-        _top_level_item: (_, original) => original,
-
-        function_definition: ($, original) => seq(
-            repeat($.hlsl_attribute),
-            original
-        ),
-        function_declarator: ($, original) => seq(
-            original,
-            optional($.semantics)
-        ),
-
-        declaration: $ => seq(
-            $._declaration_specifiers,
-            commaSep1(field('declarator', choice(
-                seq($._declarator, optional(alias(seq(':', $.expression), $.semantics))),
-                $.init_declarator
-            ))),
-            ';'
-        ),
-
-        _declaration_modifiers: ($, original) => choice(
-            'in',
-            'out',
-            'inout',
-            $.qualifiers,
-            original),
+  conflicts: ($, original) => original.concat([
+    [$.function_declarator],
+    [$.hlsl_attribute, $.subscript_designator],
+    [$.expression, $.explicit_object_parameter_declaration],
+    [$._declaration_modifiers, $.hlsl_parameter_modifier],
+  ]),
 
 
-        parameter_declaration: ($, original) =>
-            seq(
-                repeat($.hlsl_attribute),
-                original,
-                optional($.semantics),
-            ),
+  rules: {
+    _top_level_item: (_, original) => original,
 
-        semantics: $ => seq(":", $.identifier),
+    function_definition: ($, original) => seq(
+      repeat($.hlsl_attribute),
+      original
+    ),
+    function_declarator: ($, original) => seq(
+      original,
+      optional($.semantics)
+    ),
 
-        _non_case_statement: ($, original) => choice($.discard_statement, $.cbuffer_specifier, original),
+    declaration: $ => seq(
+      $._declaration_specifiers,
+      commaSep1(field('declarator', choice(
+        seq($._declarator, optional(alias(seq(':', $.expression), $.semantics))),
+        $.init_declarator
+      ))),
+      ';'
+    ),
 
-        if_statement: ($, original) => seq(repeat($.hlsl_attribute), original),
+    _declaration_modifiers: ($, original) => choice(
+      'in',
+      'out',
+      'inout',
+      $.qualifiers,
+      original),
 
-        discard_statement: _ => seq('discard', ';'),
-        qualifiers: _ => choice(
-            'precise',
-            'shared',
-            'groupshared',
-            'uniform',
-            'row_major',
-            'column_major',
-            'globallycoherent',
-            'centroid',
-            'noperspective',
-            'nointerpolation',
-            'sample',
-            'linear',
-            'snorm',
-            'unorm',
-            'point',
-            'line',
-            'triangleadj',
-            'lineadj',
-            'triangle',
-        ),
+    type_qualifier: ($, original) => choice(
+      'row_major',
+      'column_major',
+      'globallycoherent',
+      'snorm',
+      'unorm',
+      original
+    ),
 
-        cbuffer_specifier: $ => prec.right(seq(
-            'cbuffer',
-            optional($.attribute_declaration),
-            choice(
-                field('name', $._class_name),
-                seq(
-                    optional(field('name', $._class_name)),
-                    optional($.virtual_specifier),
-                    optional($.base_class_clause),
-                    field('body', $.field_declaration_list)
-                )
-            )
-        )),
 
-        hlsl_attribute: $ => seq('[',
-            $.expression,
-            ']'),
+    parameter_declaration: ($, original) =>
+      seq(
+        repeat($.hlsl_attribute),
+        repeat($.hlsl_parameter_modifier),
+        original,
+        optional($.semantics),
+      ),
 
-        for_statement: ($, original) => seq(repeat($.hlsl_attribute), original),
+    semantics: $ => seq(":", $.identifier),
 
-    }
+    _non_case_statement: ($, original) => choice($.discard_statement, $.cbuffer_specifier, original),
+
+    if_statement: ($, original) => seq(repeat($.hlsl_attribute), original),
+    while_statement: ($, original) => seq(repeat($.hlsl_attribute), original),
+
+    discard_statement: _ => seq('discard', ';'),
+    hlsl_parameter_modifier: _ => choice(
+      'in',
+      'out',
+      'inout',
+      'payload',
+      'vertices',
+      'indices',
+      'primitives',
+    ),
+    qualifiers: _ => choice(
+      'precise',
+      'shared',
+      'groupshared',
+      'uniform',
+      'centroid',
+      'noperspective',
+      'nointerpolation',
+    ),
+
+    cbuffer_specifier: $ => prec.right(seq(
+      'cbuffer',
+      optional($.attribute_declaration),
+      choice(
+        field('name', $._class_name),
+        seq(
+          optional(field('name', $._class_name)),
+          optional($.virtual_specifier),
+          optional($.base_class_clause),
+          field('body', $.field_declaration_list)
+        )
+      )
+    )),
+
+    hlsl_attribute: $ => seq('[',
+      $.expression,
+      ']'),
+
+    for_statement: ($, original) => seq(repeat($.hlsl_attribute), original),
+
+  }
 });
 
 function commaSep1(rule) {
-    return seq(rule, repeat(seq(',', rule)))
+  return seq(rule, repeat(seq(',', rule)))
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,15 +38,13 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -72,7 +70,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -82,15 +79,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -99,8 +94,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -120,22 +114,19 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "BSD-3-Clause"
+      ]
     },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -144,15 +135,13 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/node-abi": {
-      "version": "3.74.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.74.0.tgz",
-      "integrity": "sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==",
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -161,10 +150,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
-      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
-      "license": "MIT",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
+      "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }
@@ -173,7 +161,6 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -185,7 +172,6 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
       "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -198,7 +184,6 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
@@ -208,7 +193,6 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -218,7 +202,6 @@
       "resolved": "https://registry.npmjs.org/prebuildify/-/prebuildify-6.0.1.tgz",
       "integrity": "sha512-8Y2oOOateom/s8dNBsGIcnm6AxPmLH4/nanQzL5lQMU+sC0CMhzARZHizwr36pUPLdvBnOkCNQzxg4djuFSgIw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
         "mkdirp-classic": "^0.5.3",
@@ -232,11 +215,10 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -247,7 +229,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -275,15 +256,13 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -296,17 +275,15 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -319,7 +296,6 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -332,17 +308,17 @@
       }
     },
     "node_modules/tree-sitter-c": {
-      "version": "0.23.5",
-      "resolved": "git+ssh://git@github.com/tree-sitter/tree-sitter-c.git#2a265d69a4caf57108a73ad2ed1e6922dd2f998c",
+      "version": "0.24.1",
+      "resolved": "git+ssh://git@github.com/tree-sitter/tree-sitter-c.git#ae19b676b13bdcc13b7665397e6d9b14975473dd",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "node-addon-api": "^8.3.0",
+        "node-addon-api": "^8.3.1",
         "node-gyp-build": "^4.8.4"
       },
       "peerDependencies": {
-        "tree-sitter": "^0.22.1"
+        "tree-sitter": "^0.22.4"
       },
       "peerDependenciesMeta": {
         "tree-sitter": {
@@ -356,7 +332,6 @@
       "integrity": "sha512-o4gnE82pVmMMhJbWwD6+I9yr4lXii5Ci5qEQ2pFpUbVy1YiD8cizTJaqdcznA0qEbo7l2OneI1GocChPrI4YGQ==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "tree-sitter": "cli.js"
       },
@@ -366,17 +341,17 @@
     },
     "node_modules/tree-sitter-cpp": {
       "version": "0.23.4",
-      "resolved": "git+ssh://git@github.com/tree-sitter/tree-sitter-cpp.git#e5cea0ec884c5c3d2d1e41a741a66ce13da4d945",
+      "resolved": "git+ssh://git@github.com/tree-sitter/tree-sitter-cpp.git#8b5b49eb196bec7040441bee33b2c9a4838d6967",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.2.1",
         "node-gyp-build": "^4.8.2",
-        "tree-sitter-c": "^0.23.1"
+        "tree-sitter-c": "^0.24.0"
       },
       "peerDependencies": {
-        "tree-sitter": "^0.21.1"
+        "tree-sitter": "^0.22.4"
       },
       "peerDependenciesMeta": {
         "tree-sitter": {
@@ -388,15 +363,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     }
   }
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -92,6 +92,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "consteval_block_declaration"
+        },
+        {
+          "type": "SYMBOL",
           "name": "template_declaration"
         },
         {
@@ -180,14 +184,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "preproc_if"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "preproc_ifdef"
-        },
-        {
-          "type": "SYMBOL",
           "name": "preproc_include"
         },
         {
@@ -228,11 +224,41 @@
         },
         {
           "type": "SYMBOL",
+          "name": "consteval_block_declaration"
+        },
+        {
+          "type": "SYMBOL",
           "name": "template_declaration"
         },
         {
           "type": "SYMBOL",
           "name": "template_instantiation"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "export_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "import_declaration"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "preproc_if_in_block"
+          },
+          "named": true,
+          "value": "preproc_if"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "preproc_ifdef_in_block"
+          },
+          "named": true,
+          "value": "preproc_ifdef"
         },
         {
           "type": "ALIAS",
@@ -546,7 +572,7 @@
             "type": "REPEAT",
             "content": {
               "type": "SYMBOL",
-              "name": "_block_item"
+              "name": "_top_level_item"
             }
           },
           {
@@ -631,7 +657,7 @@
             "type": "REPEAT",
             "content": {
               "type": "SYMBOL",
-              "name": "_block_item"
+              "name": "_top_level_item"
             }
           },
           {
@@ -694,7 +720,7 @@
             "type": "REPEAT",
             "content": {
               "type": "SYMBOL",
-              "name": "_block_item"
+              "name": "_top_level_item"
             }
           }
         ]
@@ -731,7 +757,7 @@
             "type": "REPEAT",
             "content": {
               "type": "SYMBOL",
-              "name": "_block_item"
+              "name": "_top_level_item"
             }
           },
           {
@@ -807,7 +833,7 @@
             "type": "REPEAT",
             "content": {
               "type": "SYMBOL",
-              "name": "_block_item"
+              "name": "_top_level_item"
             }
           },
           {
@@ -2901,16 +2927,11 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "hlsl_attribute"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "hlsl_attribute"
+          }
         },
         {
           "type": "SEQ",
@@ -3481,40 +3502,83 @@
       ]
     },
     "attribute_declaration": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "[["
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "[["
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "attribute"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "attribute"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "]]"
+            }
+          ]
         },
         {
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "attribute"
+              "type": "STRING",
+              "value": "[["
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "attribute"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "annotation"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "annotation"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "]]"
             }
           ]
-        },
-        {
-          "type": "STRING",
-          "value": "]]"
         }
       ]
     },
@@ -4928,65 +4992,90 @@
       "type": "CHOICE",
       "members": [
         {
+          "type": "STRING",
+          "value": "row_major"
+        },
+        {
+          "type": "STRING",
+          "value": "column_major"
+        },
+        {
+          "type": "STRING",
+          "value": "globallycoherent"
+        },
+        {
+          "type": "STRING",
+          "value": "snorm"
+        },
+        {
+          "type": "STRING",
+          "value": "unorm"
+        },
+        {
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "const"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "const"
+                },
+                {
+                  "type": "STRING",
+                  "value": "constexpr"
+                },
+                {
+                  "type": "STRING",
+                  "value": "volatile"
+                },
+                {
+                  "type": "STRING",
+                  "value": "restrict"
+                },
+                {
+                  "type": "STRING",
+                  "value": "__restrict__"
+                },
+                {
+                  "type": "STRING",
+                  "value": "__extension__"
+                },
+                {
+                  "type": "STRING",
+                  "value": "_Atomic"
+                },
+                {
+                  "type": "STRING",
+                  "value": "_Noreturn"
+                },
+                {
+                  "type": "STRING",
+                  "value": "noreturn"
+                },
+                {
+                  "type": "STRING",
+                  "value": "_Nonnull"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "alignas_qualifier"
+                }
+              ]
             },
             {
               "type": "STRING",
-              "value": "constexpr"
+              "value": "mutable"
             },
             {
               "type": "STRING",
-              "value": "volatile"
+              "value": "constinit"
             },
             {
               "type": "STRING",
-              "value": "restrict"
-            },
-            {
-              "type": "STRING",
-              "value": "__restrict__"
-            },
-            {
-              "type": "STRING",
-              "value": "__extension__"
-            },
-            {
-              "type": "STRING",
-              "value": "_Atomic"
-            },
-            {
-              "type": "STRING",
-              "value": "_Noreturn"
-            },
-            {
-              "type": "STRING",
-              "value": "noreturn"
-            },
-            {
-              "type": "STRING",
-              "value": "_Nonnull"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "alignas_qualifier"
+              "value": "consteval"
             }
           ]
-        },
-        {
-          "type": "STRING",
-          "value": "mutable"
-        },
-        {
-          "type": "STRING",
-          "value": "constinit"
-        },
-        {
-          "type": "STRING",
-          "value": "consteval"
         }
       ]
     },
@@ -5063,6 +5152,10 @@
         {
           "type": "SYMBOL",
           "name": "dependent_type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "splice_type_specifier"
         },
         {
           "type": "SYMBOL",
@@ -5764,6 +5857,10 @@
           "name": "static_assert_declaration"
         },
         {
+          "type": "SYMBOL",
+          "name": "consteval_block_declaration"
+        },
+        {
           "type": "STRING",
           "value": ";"
         }
@@ -6091,6 +6188,10 @@
                     },
                     {
                       "type": "SYMBOL",
+                      "name": "explicit_object_parameter_declaration"
+                    },
+                    {
+                      "type": "SYMBOL",
                       "name": "optional_parameter_declaration"
                     },
                     {
@@ -6118,6 +6219,10 @@
                           {
                             "type": "SYMBOL",
                             "name": "parameter_declaration"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "explicit_object_parameter_declaration"
                           },
                           {
                             "type": "SYMBOL",
@@ -6216,6 +6321,20 @@
     "parameter_declaration": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "hlsl_attribute"
+          }
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "hlsl_parameter_modifier"
+          }
+        },
         {
           "type": "SEQ",
           "members": [
@@ -6393,6 +6512,10 @@
             },
             {
               "type": "SYMBOL",
+              "name": "expansion_statement"
+            },
+            {
+              "type": "SYMBOL",
               "name": "try_statement"
             },
             {
@@ -6483,6 +6606,10 @@
         {
           "type": "SYMBOL",
           "name": "for_range_loop"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expansion_statement"
         },
         {
           "type": "SYMBOL",
@@ -6579,16 +6706,11 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "hlsl_attribute"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "hlsl_attribute"
+          }
         },
         {
           "type": "PREC_RIGHT",
@@ -6750,24 +6872,36 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
-          "value": "while"
-        },
-        {
-          "type": "FIELD",
-          "name": "condition",
+          "type": "REPEAT",
           "content": {
             "type": "SYMBOL",
-            "name": "condition_clause"
+            "name": "hlsl_attribute"
           }
         },
         {
-          "type": "FIELD",
-          "name": "body",
-          "content": {
-            "type": "SYMBOL",
-            "name": "statement"
-          }
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "while"
+            },
+            {
+              "type": "FIELD",
+              "name": "condition",
+              "content": {
+                "type": "SYMBOL",
+                "name": "condition_clause"
+              }
+            },
+            {
+              "type": "FIELD",
+              "name": "body",
+              "content": {
+                "type": "SYMBOL",
+                "name": "statement"
+              }
+            }
+          ]
         }
       ]
     },
@@ -6808,16 +6942,11 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "hlsl_attribute"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "hlsl_attribute"
+          }
         },
         {
           "type": "SEQ",
@@ -7317,6 +7446,14 @@
         {
           "type": "SYMBOL",
           "name": "fold_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "reflect_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "splice_expression"
         }
       ]
     },
@@ -8961,20 +9098,71 @@
       }
     },
     "call_expression": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "PREC",
-          "value": 15,
-          "content": {
+      "type": "PREC_DYNAMIC",
+      "value": 1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "PREC",
+            "value": 15,
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "function",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "expression"
+                  }
+                },
+                {
+                  "type": "FIELD",
+                  "name": "arguments",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "argument_list"
+                  }
+                }
+              ]
+            }
+          },
+          {
             "type": "SEQ",
             "members": [
               {
                 "type": "FIELD",
                 "name": "function",
                 "content": {
-                  "type": "SYMBOL",
-                  "name": "expression"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "primitive_type"
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "typename"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "splice_type_specifier"
+                        }
+                      ]
+                    }
+                  ]
                 }
               },
               {
@@ -8987,29 +9175,8 @@
               }
             ]
           }
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "function",
-              "content": {
-                "type": "SYMBOL",
-                "name": "primitive_type"
-              }
-            },
-            {
-              "type": "FIELD",
-              "name": "arguments",
-              "content": {
-                "type": "SYMBOL",
-                "name": "argument_list"
-              }
-            }
-          ]
-        }
-      ]
+        ]
+      }
     },
     "gnu_asm_expression": {
       "type": "PREC",
@@ -9641,6 +9808,14 @@
                 },
                 "named": true,
                 "value": "dependent_name"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "operator_name"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "splice_expression"
               }
             ]
           }
@@ -9695,6 +9870,27 @@
                   {
                     "type": "SYMBOL",
                     "name": "primitive_type"
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "typename"
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "splice_type_specifier"
+                      }
+                    ]
                   }
                 ]
               }
@@ -11205,6 +11401,393 @@
         ]
       }
     },
+    "preproc_if_in_block": {
+      "type": "PREC",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "#[ \t]*if"
+            },
+            "named": false,
+            "value": "#if"
+          },
+          {
+            "type": "FIELD",
+            "name": "condition",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_preproc_expression"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "\n"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_block_item"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "alternative",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_else_in_block"
+                      },
+                      "named": true,
+                      "value": "preproc_else"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elif_in_block"
+                      },
+                      "named": true,
+                      "value": "preproc_elif"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elifdef_in_block"
+                      },
+                      "named": true,
+                      "value": "preproc_elifdef"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "#[ \t]*endif"
+            },
+            "named": false,
+            "value": "#endif"
+          }
+        ]
+      }
+    },
+    "preproc_ifdef_in_block": {
+      "type": "PREC",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "#[ \t]*ifdef"
+                },
+                "named": false,
+                "value": "#ifdef"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "#[ \t]*ifndef"
+                },
+                "named": false,
+                "value": "#ifndef"
+              }
+            ]
+          },
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_block_item"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "alternative",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_else_in_block"
+                      },
+                      "named": true,
+                      "value": "preproc_else"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elif_in_block"
+                      },
+                      "named": true,
+                      "value": "preproc_elif"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elifdef_in_block"
+                      },
+                      "named": true,
+                      "value": "preproc_elifdef"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "#[ \t]*endif"
+            },
+            "named": false,
+            "value": "#endif"
+          }
+        ]
+      }
+    },
+    "preproc_else_in_block": {
+      "type": "PREC",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "#[ \t]*else"
+            },
+            "named": false,
+            "value": "#else"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_block_item"
+            }
+          }
+        ]
+      }
+    },
+    "preproc_elif_in_block": {
+      "type": "PREC",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "PATTERN",
+              "value": "#[ \t]*elif"
+            },
+            "named": false,
+            "value": "#elif"
+          },
+          {
+            "type": "FIELD",
+            "name": "condition",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_preproc_expression"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "\n"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_block_item"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "alternative",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_else_in_block"
+                      },
+                      "named": true,
+                      "value": "preproc_else"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elif_in_block"
+                      },
+                      "named": true,
+                      "value": "preproc_elif"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elifdef_in_block"
+                      },
+                      "named": true,
+                      "value": "preproc_elifdef"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "preproc_elifdef_in_block": {
+      "type": "PREC",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "#[ \t]*elifdef"
+                },
+                "named": false,
+                "value": "#elifdef"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "PATTERN",
+                  "value": "#[ \t]*elifndef"
+                },
+                "named": false,
+                "value": "#elifndef"
+              }
+            ]
+          },
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_block_item"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "alternative",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_else_in_block"
+                      },
+                      "named": true,
+                      "value": "preproc_else"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elif_in_block"
+                      },
+                      "named": true,
+                      "value": "preproc_elif"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "preproc_elifdef_in_block"
+                      },
+                      "named": true,
+                      "value": "preproc_elifdef"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
     "placeholder_type_specifier": {
       "type": "PREC",
       "value": 1,
@@ -11218,8 +11801,26 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "type_specifier"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "qualified_type_identifier"
+                      },
+                      "named": true,
+                      "value": "qualified_identifier"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "template_type"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_type_identifier"
+                    }
+                  ]
                 },
                 {
                   "type": "BLANK"
@@ -11291,6 +11892,19 @@
         {
           "type": "STRING",
           "value": ")"
+        }
+      ]
+    },
+    "annotation": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
         }
       ]
     },
@@ -11451,6 +12065,10 @@
           {
             "type": "SYMBOL",
             "name": "template_type"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "splice_type_specifier"
           },
           {
             "type": "ALIAS",
@@ -11875,58 +12493,34 @@
       ]
     },
     "export_declaration": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "export"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_block_item"
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "{"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_block_item"
-                  }
-                },
-                {
-                  "type": "STRING",
-                  "value": "}"
-                }
-              ]
-            }
-          ]
-        }
-      ]
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "export"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_block_item"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "declaration_list"
+              }
+            ]
+          }
+        ]
+      }
     },
     "import_declaration": {
       "type": "SEQ",
       "members": [
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "export"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
         {
           "type": "STRING",
           "value": "import"
@@ -12120,37 +12714,53 @@
       ]
     },
     "template_instantiation": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "template"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "extern"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "template"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_declaration_specifiers"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "FIELD",
+            "name": "declarator",
+            "content": {
               "type": "SYMBOL",
-              "name": "_declaration_specifiers"
-            },
-            {
-              "type": "BLANK"
+              "name": "_declarator"
             }
-          ]
-        },
-        {
-          "type": "FIELD",
-          "name": "declarator",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_declarator"
+          },
+          {
+            "type": "STRING",
+            "value": ";"
           }
-        },
-        {
-          "type": "STRING",
-          "value": ";"
-        }
-      ]
+        ]
+      }
     },
     "template_parameter_list": {
       "type": "SEQ",
@@ -12417,6 +13027,19 @@
               "name": "optional_type_parameter_declaration"
             }
           ]
+        }
+      ]
+    },
+    "explicit_object_parameter_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "this"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "parameter_declaration"
         }
       ]
     },
@@ -13915,6 +14538,10 @@
             {
               "type": "SYMBOL",
               "name": "nested_namespace_specifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "splice_specifier"
             }
           ]
         },
@@ -14028,6 +14655,10 @@
             {
               "type": "SYMBOL",
               "name": "qualified_identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "splice_type_specifier"
             }
           ]
         },
@@ -14128,6 +14759,23 @@
         {
           "type": "STRING",
           "value": ";"
+        }
+      ]
+    },
+    "consteval_block_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "consteval"
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "compound_statement"
+          }
         }
       ]
     },
@@ -15194,6 +15842,27 @@
         }
       ]
     },
+    "lambda_specifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "static"
+        },
+        {
+          "type": "STRING",
+          "value": "constexpr"
+        },
+        {
+          "type": "STRING",
+          "value": "consteval"
+        },
+        {
+          "type": "STRING",
+          "value": "mutable"
+        }
+      ]
+    },
     "lambda_declarator": {
       "type": "CHOICE",
       "members": [
@@ -15216,16 +15885,11 @@
               }
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "type_qualifier"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "lambda_specifier"
+              }
             },
             {
               "type": "CHOICE",
@@ -15341,8 +16005,11 @@
               }
             },
             {
-              "type": "SYMBOL",
-              "name": "type_qualifier"
+              "type": "REPEAT1",
+              "content": {
+                "type": "SYMBOL",
+                "name": "lambda_specifier"
+              }
             },
             {
               "type": "CHOICE",
@@ -16897,6 +17564,14 @@
                       "name": "decltype"
                     },
                     {
+                      "type": "SYMBOL",
+                      "name": "splice_expression"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "splice_type_specifier"
+                    },
+                    {
                       "type": "ALIAS",
                       "content": {
                         "type": "SYMBOL",
@@ -16957,7 +17632,7 @@
               },
               {
                 "type": "PREC_DYNAMIC",
-                "value": 1,
+                "value": 2,
                 "content": {
                   "type": "SYMBOL",
                   "name": "_field_identifier"
@@ -16999,25 +17674,29 @@
                 "name": "template_function"
               },
               {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "template"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  }
-                ]
+                "type": "PREC_DYNAMIC",
+                "value": 1,
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "template"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    }
+                  ]
+                }
               },
               {
                 "type": "SYMBOL",
@@ -17072,8 +17751,12 @@
                 "name": "template_type"
               },
               {
-                "type": "SYMBOL",
-                "name": "_type_identifier"
+                "type": "PREC_DYNAMIC",
+                "value": 1,
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_type_identifier"
+                }
               }
             ]
           }
@@ -17202,6 +17885,142 @@
                 "name": "initializer_list"
               }
             ]
+          }
+        }
+      ]
+    },
+    "reflect_expression": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "^^"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "::"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "type_descriptor"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "splice_specifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "[:"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "STRING",
+          "value": ":]"
+        }
+      ]
+    },
+    "_splice_specialization_specifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "splice_specifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "template_argument_list"
+        }
+      ]
+    },
+    "splice_type_specifier": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "splice_specifier"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_splice_specialization_specifier"
+          }
+        ]
+      }
+    },
+    "splice_expression": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "splice_specifier"
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "template"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_splice_specialization_specifier"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "expansion_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "template"
+        },
+        {
+          "type": "STRING",
+          "value": "for"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_for_range_loop_body"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "statement"
           }
         }
       ]
@@ -17543,6 +18362,39 @@
         }
       ]
     },
+    "hlsl_parameter_modifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "in"
+        },
+        {
+          "type": "STRING",
+          "value": "out"
+        },
+        {
+          "type": "STRING",
+          "value": "inout"
+        },
+        {
+          "type": "STRING",
+          "value": "payload"
+        },
+        {
+          "type": "STRING",
+          "value": "vertices"
+        },
+        {
+          "type": "STRING",
+          "value": "indices"
+        },
+        {
+          "type": "STRING",
+          "value": "primitives"
+        }
+      ]
+    },
     "qualifiers": {
       "type": "CHOICE",
       "members": [
@@ -17564,18 +18416,6 @@
         },
         {
           "type": "STRING",
-          "value": "row_major"
-        },
-        {
-          "type": "STRING",
-          "value": "column_major"
-        },
-        {
-          "type": "STRING",
-          "value": "globallycoherent"
-        },
-        {
-          "type": "STRING",
           "value": "centroid"
         },
         {
@@ -17585,42 +18425,6 @@
         {
           "type": "STRING",
           "value": "nointerpolation"
-        },
-        {
-          "type": "STRING",
-          "value": "sample"
-        },
-        {
-          "type": "STRING",
-          "value": "linear"
-        },
-        {
-          "type": "STRING",
-          "value": "snorm"
-        },
-        {
-          "type": "STRING",
-          "value": "unorm"
-        },
-        {
-          "type": "STRING",
-          "value": "point"
-        },
-        {
-          "type": "STRING",
-          "value": "line"
-        },
-        {
-          "type": "STRING",
-          "value": "triangleadj"
-        },
-        {
-          "type": "STRING",
-          "value": "lineadj"
-        },
-        {
-          "type": "STRING",
-          "value": "triangle"
         }
       ]
     },
@@ -17798,6 +18602,12 @@
       "qualified_identifier"
     ],
     [
+      "template_function",
+      "template_type",
+      "qualified_identifier",
+      "qualified_type_identifier"
+    ],
+    [
       "template_type",
       "qualified_type_identifier"
     ],
@@ -17884,12 +18694,38 @@
       "template_type"
     ],
     [
+      "field_expression",
+      "template_method"
+    ],
+    [
       "qualified_field_identifier",
       "template_method",
       "template_type"
     ],
     [
+      "type_specifier",
+      "template_type",
+      "template_function",
+      "expression"
+    ],
+    [
+      "splice_type_specifier",
+      "splice_expression"
+    ],
+    [
       "function_declarator"
+    ],
+    [
+      "hlsl_attribute",
+      "subscript_designator"
+    ],
+    [
+      "expression",
+      "explicit_object_parameter_declaration"
+    ],
+    [
+      "_declaration_modifiers",
+      "hlsl_parameter_modifier"
     ]
   ],
   "precedences": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -276,6 +276,10 @@
         "named": true
       },
       {
+        "type": "reflect_expression",
+        "named": true
+      },
+      {
         "type": "requires_clause",
         "named": true
       },
@@ -285,6 +289,10 @@
       },
       {
         "type": "sizeof_expression",
+        "named": true
+      },
+      {
+        "type": "splice_expression",
         "named": true
       },
       {
@@ -363,6 +371,10 @@
       },
       {
         "type": "do_statement",
+        "named": true
+      },
+      {
+        "type": "expansion_statement",
         "named": true
       },
       {
@@ -453,6 +465,10 @@
       },
       {
         "type": "sized_type_specifier",
+        "named": true
+      },
+      {
+        "type": "splice_type_specifier",
         "named": true
       },
       {
@@ -726,6 +742,21 @@
     }
   },
   {
+    "type": "annotation",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "argument_list",
     "named": true,
     "fields": {},
@@ -947,6 +978,10 @@
       "required": true,
       "types": [
         {
+          "type": "annotation",
+          "named": true
+        },
+        {
           "type": "attribute",
           "named": true
         }
@@ -1032,6 +1067,10 @@
         },
         {
           "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "splice_type_specifier",
           "named": true
         },
         {
@@ -1220,7 +1259,7 @@
         ]
       },
       "function": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
@@ -1230,6 +1269,14 @@
           {
             "type": "primitive_type",
             "named": true
+          },
+          {
+            "type": "splice_type_specifier",
+            "named": true
+          },
+          {
+            "type": "typename",
+            "named": false
           }
         ]
       }
@@ -1292,6 +1339,10 @@
         },
         {
           "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expansion_statement",
           "named": true
         },
         {
@@ -1428,6 +1479,10 @@
             "named": true
           },
           {
+            "type": "splice_type_specifier",
+            "named": true
+          },
+          {
             "type": "template_type",
             "named": true
           },
@@ -1496,6 +1551,10 @@
         "types": [
           {
             "type": "qualified_identifier",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
             "named": true
           },
           {
@@ -1631,7 +1690,7 @@
     "named": true,
     "fields": {
       "type": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
@@ -1640,6 +1699,10 @@
           },
           {
             "type": "qualified_identifier",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
             "named": true
           },
           {
@@ -1653,6 +1716,10 @@
           {
             "type": "type_identifier",
             "named": true
+          },
+          {
+            "type": "typename",
+            "named": false
           }
         ]
       },
@@ -1704,11 +1771,23 @@
           "named": true
         },
         {
+          "type": "consteval_block_declaration",
+          "named": true
+        },
+        {
           "type": "declaration",
           "named": true
         },
         {
+          "type": "export_declaration",
+          "named": true
+        },
+        {
           "type": "function_definition",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
           "named": true
         },
         {
@@ -1902,6 +1981,22 @@
     }
   },
   {
+    "type": "consteval_block_declaration",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "compound_statement",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "constraint_conjunction",
     "named": true,
     "fields": {
@@ -1927,6 +2022,10 @@
           },
           {
             "type": "expression",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
             "named": true
           },
           {
@@ -1978,6 +2077,10 @@
             "named": true
           },
           {
+            "type": "splice_type_specifier",
+            "named": true
+          },
+          {
             "type": "template_type",
             "named": true
           },
@@ -2015,6 +2118,10 @@
           },
           {
             "type": "expression",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
             "named": true
           },
           {
@@ -2063,6 +2170,10 @@
           },
           {
             "type": "expression",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
             "named": true
           },
           {
@@ -2195,11 +2306,23 @@
           "named": true
         },
         {
+          "type": "consteval_block_declaration",
+          "named": true
+        },
+        {
           "type": "declaration",
           "named": true
         },
         {
+          "type": "export_declaration",
+          "named": true
+        },
+        {
           "type": "function_definition",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
           "named": true
         },
         {
@@ -2457,6 +2580,10 @@
             "named": true
           },
           {
+            "type": "splice_type_specifier",
+            "named": true
+          },
+          {
             "type": "template_type",
             "named": true
           },
@@ -2532,6 +2659,96 @@
     }
   },
   {
+    "type": "expansion_statement",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "statement",
+            "named": true
+          }
+        ]
+      },
+      "declarator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_declarator",
+            "named": true
+          }
+        ]
+      },
+      "initializer": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "init_statement",
+            "named": true
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          },
+          {
+            "type": "initializer_list",
+            "named": true
+          }
+        ]
+      },
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "type_specifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "attribute_declaration",
+          "named": true
+        },
+        {
+          "type": "attribute_specifier",
+          "named": true
+        },
+        {
+          "type": "ms_declspec_modifier",
+          "named": true
+        },
+        {
+          "type": "qualifiers",
+          "named": true
+        },
+        {
+          "type": "storage_class_specifier",
+          "named": true
+        },
+        {
+          "type": "type_qualifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "explicit_function_specifier",
     "named": true,
     "fields": {},
@@ -2547,12 +2764,31 @@
     }
   },
   {
-    "type": "export_declaration",
+    "type": "explicit_object_parameter_declaration",
     "named": true,
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
+      "types": [
+        {
+          "type": "parameter_declaration",
+          "named": true
+        },
+        {
+          "type": "this",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "export_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
       "types": [
         {
           "type": "alias_declaration",
@@ -2563,11 +2799,27 @@
           "named": true
         },
         {
+          "type": "consteval_block_declaration",
+          "named": true
+        },
+        {
           "type": "declaration",
           "named": true
         },
         {
+          "type": "declaration_list",
+          "named": true
+        },
+        {
+          "type": "export_declaration",
+          "named": true
+        },
+        {
           "type": "function_definition",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
           "named": true
         },
         {
@@ -2762,6 +3014,10 @@
           "named": true
         },
         {
+          "type": "consteval_block_declaration",
+          "named": true
+        },
+        {
           "type": "declaration",
           "named": true
         },
@@ -2862,7 +3118,15 @@
             "named": true
           },
           {
+            "type": "operator_name",
+            "named": true
+          },
+          {
             "type": "qualified_identifier",
+            "named": true
+          },
+          {
+            "type": "splice_expression",
             "named": true
           },
           {
@@ -3281,7 +3545,7 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {
@@ -3309,6 +3573,10 @@
         },
         {
           "type": "qualified_identifier",
+          "named": true
+        },
+        {
+          "type": "splice_type_specifier",
           "named": true
         },
         {
@@ -3795,6 +4063,11 @@
     }
   },
   {
+    "type": "hlsl_parameter_modifier",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "if_statement",
     "named": true,
     "fields": {
@@ -3830,7 +4103,7 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {
@@ -4131,6 +4404,10 @@
           "named": true
         },
         {
+          "type": "lambda_specifier",
+          "named": true
+        },
+        {
           "type": "noexcept",
           "named": true
         },
@@ -4144,10 +4421,6 @@
         },
         {
           "type": "trailing_return_type",
-          "named": true
-        },
-        {
-          "type": "type_qualifier",
           "named": true
         }
       ]
@@ -4213,6 +4486,11 @@
         ]
       }
     }
+  },
+  {
+    "type": "lambda_specifier",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "linkage_specification",
@@ -4406,6 +4684,10 @@
         },
         {
           "type": "nested_namespace_specifier",
+          "named": true
+        },
+        {
+          "type": "splice_specifier",
           "named": true
         }
       ]
@@ -4801,6 +5083,14 @@
           "named": true
         },
         {
+          "type": "hlsl_attribute",
+          "named": true
+        },
+        {
+          "type": "hlsl_parameter_modifier",
+          "named": true
+        },
+        {
           "type": "ms_declspec_modifier",
           "named": true
         },
@@ -4831,6 +5121,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "explicit_object_parameter_declaration",
+          "named": true
+        },
         {
           "type": "optional_parameter_declaration",
           "named": true
@@ -4929,7 +5223,15 @@
         "required": false,
         "types": [
           {
-            "type": "type_specifier",
+            "type": "qualified_identifier",
+            "named": true
+          },
+          {
+            "type": "template_type",
+            "named": true
+          },
+          {
+            "type": "type_identifier",
             "named": true
           }
         ]
@@ -5201,11 +5503,19 @@
           "named": true
         },
         {
+          "type": "consteval_block_declaration",
+          "named": true
+        },
+        {
           "type": "declaration",
           "named": true
         },
         {
           "type": "enumerator",
+          "named": true
+        },
+        {
+          "type": "export_declaration",
           "named": true
         },
         {
@@ -5221,7 +5531,19 @@
           "named": true
         },
         {
+          "type": "global_module_fragment_declaration",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
           "type": "linkage_specification",
+          "named": true
+        },
+        {
+          "type": "module_declaration",
           "named": true
         },
         {
@@ -5254,6 +5576,10 @@
         },
         {
           "type": "preproc_include",
+          "named": true
+        },
+        {
+          "type": "private_module_fragment_declaration",
           "named": true
         },
         {
@@ -5337,11 +5663,19 @@
           "named": true
         },
         {
+          "type": "consteval_block_declaration",
+          "named": true
+        },
+        {
           "type": "declaration",
           "named": true
         },
         {
           "type": "enumerator",
+          "named": true
+        },
+        {
+          "type": "export_declaration",
           "named": true
         },
         {
@@ -5357,7 +5691,19 @@
           "named": true
         },
         {
+          "type": "global_module_fragment_declaration",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
           "type": "linkage_specification",
+          "named": true
+        },
+        {
+          "type": "module_declaration",
           "named": true
         },
         {
@@ -5390,6 +5736,10 @@
         },
         {
           "type": "preproc_include",
+          "named": true
+        },
+        {
+          "type": "private_module_fragment_declaration",
           "named": true
         },
         {
@@ -5444,11 +5794,19 @@
           "named": true
         },
         {
+          "type": "consteval_block_declaration",
+          "named": true
+        },
+        {
           "type": "declaration",
           "named": true
         },
         {
           "type": "enumerator",
+          "named": true
+        },
+        {
+          "type": "export_declaration",
           "named": true
         },
         {
@@ -5464,7 +5822,19 @@
           "named": true
         },
         {
+          "type": "global_module_fragment_declaration",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
           "type": "linkage_specification",
+          "named": true
+        },
+        {
+          "type": "module_declaration",
           "named": true
         },
         {
@@ -5497,6 +5867,10 @@
         },
         {
           "type": "preproc_include",
+          "named": true
+        },
+        {
+          "type": "private_module_fragment_declaration",
           "named": true
         },
         {
@@ -5644,11 +6018,19 @@
           "named": true
         },
         {
+          "type": "consteval_block_declaration",
+          "named": true
+        },
+        {
           "type": "declaration",
           "named": true
         },
         {
           "type": "enumerator",
+          "named": true
+        },
+        {
+          "type": "export_declaration",
           "named": true
         },
         {
@@ -5664,7 +6046,19 @@
           "named": true
         },
         {
+          "type": "global_module_fragment_declaration",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
           "type": "linkage_specification",
+          "named": true
+        },
+        {
+          "type": "module_declaration",
           "named": true
         },
         {
@@ -5697,6 +6091,10 @@
         },
         {
           "type": "preproc_include",
+          "named": true
+        },
+        {
+          "type": "private_module_fragment_declaration",
           "named": true
         },
         {
@@ -5780,11 +6178,19 @@
           "named": true
         },
         {
+          "type": "consteval_block_declaration",
+          "named": true
+        },
+        {
           "type": "declaration",
           "named": true
         },
         {
           "type": "enumerator",
+          "named": true
+        },
+        {
+          "type": "export_declaration",
           "named": true
         },
         {
@@ -5800,7 +6206,19 @@
           "named": true
         },
         {
+          "type": "global_module_fragment_declaration",
+          "named": true
+        },
+        {
+          "type": "import_declaration",
+          "named": true
+        },
+        {
           "type": "linkage_specification",
+          "named": true
+        },
+        {
+          "type": "module_declaration",
           "named": true
         },
         {
@@ -5833,6 +6251,10 @@
         },
         {
           "type": "preproc_include",
+          "named": true
+        },
+        {
+          "type": "private_module_fragment_declaration",
           "named": true
         },
         {
@@ -5998,6 +6420,14 @@
             "named": true
           },
           {
+            "type": "splice_expression",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
+            "named": true
+          },
+          {
             "type": "template_type",
             "named": true
           }
@@ -6073,6 +6503,25 @@
     }
   },
   {
+    "type": "reflect_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "type_descriptor",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "requirement_seq",
     "named": true,
     "fields": {},
@@ -6121,6 +6570,10 @@
           },
           {
             "type": "expression",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
             "named": true
           },
           {
@@ -6352,6 +6805,59 @@
     }
   },
   {
+    "type": "splice_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "splice_specifier",
+          "named": true
+        },
+        {
+          "type": "template_argument_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "splice_specifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "splice_type_specifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "splice_specifier",
+          "named": true
+        },
+        {
+          "type": "template_argument_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "static_assert_declaration",
     "named": true,
     "fields": {
@@ -6429,6 +6935,10 @@
         "types": [
           {
             "type": "qualified_identifier",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
             "named": true
           },
           {
@@ -6971,6 +7481,10 @@
           "named": true
         },
         {
+          "type": "consteval_block_declaration",
+          "named": true
+        },
+        {
           "type": "continue_statement",
           "named": true
         },
@@ -6980,6 +7494,10 @@
         },
         {
           "type": "do_statement",
+          "named": true
+        },
+        {
+          "type": "expansion_statement",
           "named": true
         },
         {
@@ -7262,6 +7780,10 @@
           "named": true
         },
         {
+          "type": "splice_type_specifier",
+          "named": true
+        },
+        {
           "type": "template_type",
           "named": true
         },
@@ -7342,6 +7864,10 @@
         "types": [
           {
             "type": "qualified_identifier",
+            "named": true
+          },
+          {
+            "type": "splice_type_specifier",
             "named": true
           },
           {
@@ -7470,6 +7996,10 @@
         {
           "type": "qualified_identifier",
           "named": true
+        },
+        {
+          "type": "splice_type_specifier",
+          "named": true
         }
       ]
     }
@@ -7593,6 +8123,16 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "hlsl_attribute",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -7764,6 +8304,10 @@
     "named": false
   },
   {
+    "type": ":]",
+    "named": false
+  },
+  {
     "type": ";",
     "named": false
   },
@@ -7852,6 +8396,10 @@
     "named": false
   },
   {
+    "type": "[:",
+    "named": false
+  },
+  {
     "type": "[[",
     "named": false
   },
@@ -7873,6 +8421,10 @@
   },
   {
     "type": "^=",
+    "named": false
+  },
+  {
+    "type": "^^",
     "named": false
   },
   {
@@ -8216,23 +8768,15 @@
     "named": false
   },
   {
+    "type": "indices",
+    "named": false
+  },
+  {
     "type": "inline",
     "named": false
   },
   {
     "type": "inout",
-    "named": false
-  },
-  {
-    "type": "line",
-    "named": false
-  },
-  {
-    "type": "lineadj",
-    "named": false
-  },
-  {
-    "type": "linear",
     "named": false
   },
   {
@@ -8332,7 +8876,7 @@
     "named": false
   },
   {
-    "type": "point",
+    "type": "payload",
     "named": false
   },
   {
@@ -8350,6 +8894,10 @@
   {
     "type": "primitive_type",
     "named": true
+  },
+  {
+    "type": "primitives",
+    "named": false
   },
   {
     "type": "private",
@@ -8389,10 +8937,6 @@
   },
   {
     "type": "row_major",
-    "named": false
-  },
-  {
-    "type": "sample",
     "named": false
   },
   {
@@ -8460,14 +9004,6 @@
     "named": false
   },
   {
-    "type": "triangle",
-    "named": false
-  },
-  {
-    "type": "triangleadj",
-    "named": false
-  },
-  {
     "type": "true",
     "named": true
   },
@@ -8529,6 +9065,10 @@
   },
   {
     "type": "using",
+    "named": false
+  },
+  {
+    "type": "vertices",
     "named": false
   },
   {

--- a/test/corpus/basic.txt
+++ b/test/corpus/basic.txt
@@ -635,3 +635,91 @@ struct OcclusionScreenRayMarch {
             (identifier))
           (return_statement
             (identifier)))))))
+
+================================================================================
+Top-level HLSL attributes
+================================================================================
+
+[shader("compute")]
+[numthreads(64, 1, 1)]
+void ClearMaterialCountersCS(uint3 dispatchThreadId : SV_DispatchThreadID) {
+}
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (function_definition
+    (hlsl_attribute
+      (call_expression
+        (identifier)
+        (argument_list
+          (string_literal
+            (string_content)))))
+    (hlsl_attribute
+      (call_expression
+        (identifier)
+        (argument_list
+          (number_literal)
+          (number_literal)
+          (number_literal))))
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list
+        (parameter_declaration
+          (type_identifier)
+          (identifier)
+          (semantics
+            (identifier)))))
+    (compound_statement)))
+
+================================================================================
+Contextual sample identifier
+================================================================================
+
+void f() {
+    MaterialUvSample sample = (MaterialUvSample)0;
+    sample.uvSetIndex = 0u;
+}
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (function_definition
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list))
+    (compound_statement
+      (declaration
+        (type_identifier)
+        (init_declarator
+          (identifier)
+          (cast_expression
+            (type_descriptor
+              (type_identifier))
+            (number_literal))))
+      (expression_statement
+        (assignment_expression
+          (field_expression
+            (identifier)
+            (field_identifier))
+          (number_literal))))))
+
+================================================================================
+Typed UAV format qualifier
+================================================================================
+
+RWTexture2D<unorm float> g_outWorkingEdges;
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (declaration
+    (template_type
+      (type_identifier)
+      (template_argument_list
+        (type_descriptor
+          (type_qualifiers)
+          (primitive_type))))
+    (identifier)))


### PR DESCRIPTION
With shader model 6.8 (sources at bottom), parameter declarations can now have decorators. For example, this is now a valid HLSL function:

```hlsl
  [Shader("node")]
  [NodeLaunch("broadcasting")]
  [NumThreads(4,5,6)]
  void myFancyNode(  
      DispatchNodeInputRecord<MY_INPUT_RECORD> myInput,
      [MaxRecords(4)] NodeOutput<MY_RECORD> myFascinatingNode,
      [NodeID("myNiftyNode",3)] [MaxRecords(4)] NodeOutput<MY_RECORD> myRecords,
      [MaxRecordsSharedWith(myRecords)]
      [AllowSparseNodes]
      [NodeArraySize(63)] NodeOutputArray<MY_MATERIAL_RECORD> myMaterials,
      [MaxRecords(20)] EmptyNodeOutput myProgressCounter
      )
  {
  }
```

As such, parameter declarations need ```repeat($.hlsl_attribute),```- without this, function parsing is broken.

Additionally, function declarations can also have multiple decorators per the HLSL spec (also shown above), so ```function_definition``` needs ```repeat``` instead of ```optional```.

The same goes for flow control, where more than one decorator is allowed by the spec (though the compiler will reject certain combinations). I'm not sure how to represent more complicated conditions like that- for example, ```[branch][flatten]``` and ```[loop][unroll]``` would both be nonsensical. It seems safest to allow more than one in the grammar for now, at least.

https://microsoft.github.io/DirectX-Specs/d3d/HLSL_ShaderModel6_8.html
https://microsoft.github.io/DirectX-Specs/d3d/WorkGraphs.html